### PR TITLE
Warn about PATH during non-interactive install

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Or from a cloned repo:
 
 - Installs `codexcondom` to `~/.local/bin` under your home (or `/root` if run as root)
 - Copies runtime Containerfile into `~/.local/share/codexcondoms/`
-- Ensures `~/.local/bin` is on PATH (automatically for the one-liner; prompts when interactive)
+- Prompts to add `~/.local/bin` to PATH when interactive; warns otherwise if missing
 
 ## Security Note
 

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 die() { echo "[ERROR] $*" >&2; exit 1; }
 info() { echo "[INFO] $*" >&2; }
+warn() { echo "[WARN] $*" >&2; }
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT="$SCRIPT_DIR"
@@ -138,8 +139,8 @@ main() {
         *) add_path=0 ;;
       esac
     else
-      # Non-interactive (e.g., curl|bash): update PATH automatically
-      add_path=1
+      # Non-interactive: warn but do not modify PATH
+      warn "$TARGET_BIN_DIR is not in PATH. Add it to use codexcondom."
     fi
   else
     add_path=0


### PR DESCRIPTION
## Summary
- add warning helper
- alert when ~/.local/bin isn't on PATH during non-interactive install
- clarify install docs about PATH warning behavior

## Testing
- `shellcheck install.sh`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fc744b04832780563eb8942ed5d6